### PR TITLE
Fixed typo + de.catkeys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ OPTIMIZE :=
 # 	will recreate only the "locales/en.catkeys" file. Use it as a template
 # 	for creating catkeys for other languages. All localization files must be
 # 	placed in the "locales" subdirectory.
-LOCALES = 
+LOCALES = de en
 
 #	Specify all the preprocessor symbols to be defined. The symbols will not
 #	have their values set automatically; you must supply the value (if any) to

--- a/Source/ClockView.cpp
+++ b/Source/ClockView.cpp
@@ -500,7 +500,7 @@ ClockView::MessageReceived(BMessage *msg)
 		Update();
 		break;
 	case B_ABOUT_REQUESTED: {
-		BAlert *alert = new BAlert(B_TRANSLATE("About WorldClock"),
+		BAlert *alert = new BAlert(B_TRANSLATE("About WordClock"),
 			B_TRANSLATE("WordClock (The Replicant version)"),
 			B_TRANSLATE("OK"));
 		alert->SetFlags(alert->Flags() | B_CLOSE_ON_ESCAPE);

--- a/locales/de.catkeys
+++ b/locales/de.catkeys
@@ -1,0 +1,31 @@
+1	German	x-vnd.janus.WordClock	224949292
+About WordClock	ClockView		Über WordClock
+Background	ClockView		Hintergrund
+Default	ClockView		Standard
+EIGHT	ClockView		ACHT
+ELEVEN	ClockView		ELF
+FIVE	ClockView		FÜNF
+FOUR	ClockView		VIER
+HALF	ClockView		HALB
+IT IS	ClockView		ES IST
+MINUTES	ClockView		MINUTEN
+NINE	ClockView		NEUN
+O'CLOCK	ClockView		UHR
+OK	ClockView		OK
+ONE	ClockView		EINS
+PAST	ClockView		NACH
+QUARTER	ClockView		VIERTEL
+SEVEN	ClockView		SIEBEN
+SIX	ClockView		SECHS
+TEN	ClockView		ZEHN
+Text	ClockView		Text
+THREE	ClockView		DREI
+TO	ClockView		VOR
+Transparent	ClockView		Transparent
+TWELVE	ClockView		ZWÖLF
+TWENTY	ClockView		ZWANZIG
+TWO	ClockView		ZWEI
+WordClock (The Replicant version)	ClockView		WordClock (die Replikant Version)
+Font	MainWindow		Schrift
+Size	MainWindow		Größe
+WordClock	System name		WordClock

--- a/locales/en.catkeys
+++ b/locales/en.catkeys
@@ -1,0 +1,31 @@
+1	English	x-vnd.janus.WordClock	224949292
+About WordClock	ClockView		About WordClock
+Background	ClockView		Background
+Default	ClockView		Default
+EIGHT	ClockView		EIGHT
+ELEVEN	ClockView		ELEVEN
+FIVE	ClockView		FIVE
+FOUR	ClockView		FOUR
+HALF	ClockView		HALF
+IT IS	ClockView		IT IS
+MINUTES	ClockView		MINUTES
+NINE	ClockView		NINE
+O'CLOCK	ClockView		O'CLOCK
+OK	ClockView		OK
+ONE	ClockView		ONE
+PAST	ClockView		PAST
+QUARTER	ClockView		QUARTER
+SEVEN	ClockView		SEVEN
+SIX	ClockView		SIX
+TEN	ClockView		TEN
+Text	ClockView		Text
+THREE	ClockView		THREE
+TO	ClockView		TO
+Transparent	ClockView		Transparent
+TWELVE	ClockView		TWELVE
+TWENTY	ClockView		TWENTY
+TWO	ClockView		TWO
+WordClock (The Replicant version)	ClockView		WordClock (The Replicant version)
+Font	MainWindow		Font
+Size	MainWindow		Size
+WordClock	System name		WordClock


### PR DESCRIPTION
Have a try with the German locale. It doesn't look as nice as with English.
You may want to wreck your brain, how to locale-dependently arrange the words... :)

BTW, you want a recipe created for WordClock, or not yet?
I think, at with the English locale, it's very nice.